### PR TITLE
Require Craft 3 RC1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         }
     },
     "require": {
+        "craftcms/cms": "^3.0.0-RC1",
         "erusev/parsedown": "^1.6",
         "erusev/parsedown-extra": "^0.7.1",
         "michelf/php-smartypants": "^1.8"


### PR DESCRIPTION
The Plugin Store is eventually going to require that plugins define their Craft CMS compatibility, via the `require` property in composer.json.