### PR TITLE
Require stable-version of parsedown specifically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require": {
         "craftcms/cms": "^3.0.0-RC1",
-        "erusev/parsedown": "^1.6",
+        "erusev/parsedown": "^1.6@stable",
         "erusev/parsedown-extra": "^0.7.1",
         "michelf/php-smartypants": "^1.8"
     }


### PR DESCRIPTION
This fixes #16 

As a more general alternative, we could also set [`prefer-stable`](https://getcomposer.org/doc/04-schema.md#prefer-stable) in `composer.json` to get stable-releases in general. As far as I understand it, this would still allow for requiring non-stable versions of _specific_ packages.

Let me know what you like @selvinortiz 