### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Doxter.php
+++ b/src/Doxter.php
@@ -28,7 +28,7 @@ class Doxter extends Plugin
     {
         parent::init();
 
-        Craft::$app->view->twig->addExtension(new DoxterExtension());
+        Craft::$app->view->registerTwigExtension(new DoxterExtension());
 
         Event::on(
             Fields::className(),


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.