### PR TITLE
Add CraftQL support for `text` and `html` fields.

### DIFF
--- a/src/Doxter.php
+++ b/src/Doxter.php
@@ -39,6 +39,32 @@ class Doxter extends Plugin
             }
         );
 
+        if (class_exists(\markhuot\CraftQL\CraftQL::class))
+        {
+            Event::on(
+                DoxterField::class,
+                'craftQlGetFieldSchema',
+                function($event) 
+                {
+                    $event->handled = true;
+
+                    $outputSchema = $event->schema->createObjectType(ucfirst($event->sender->handle).'DoxterFieldData');
+
+                    $outputSchema->addStringField('text')
+                        ->resolve(function($root) {
+                            return (string)$root->getRaw();
+                        });
+
+                    $outputSchema->addStringField('html')
+                        ->resolve(function($root) {
+                            return (string)$root->getHtml();
+                        });
+
+                    $event->schema->addField($event->sender)->type($outputSchema);
+                }
+            );
+        }
+
         $this->name          = $this->getSettings()->pluginAlias;
         $this->hasCpSection  = $this->getSettings()->enableCpTab;
         $this->hasCpSettings = true;


### PR DESCRIPTION
Hi Selvin! I'm playing with CraftQL and just Doxter to play nice. Previously, using the field handle in a GraphQL query would have resulted in an error:

Query:

```
{
    entries {
        ... on Blog {
            doxterFieldHandle
        }
    }
}
```

Result:

> String cannot represent non scalar value: instance of selvinortiz\doxter\fields\data\DoxterData

This PR requires a sub-selection of either `text` or `html`. Query:

```
{
    entries {
        ... on Blog {
            doxterFieldHandle {
                text
                html
            }
        }
    }
}
```

More thrilling result:

```
{
    "data": {
        "entries": [
        {
            "text": "GraphQL is the bee's knees, and it's just *begging* to get Markdown from Doxter.",
            "html": "<p>GraphQL is the bee&#8217;s knees, and it&#8217;s just <em>begging</em> to get Markdown from Doxter.</p>"
        }
    ]
}
```