### PR TITLE
Fix Shortcode::parseAttributes

### DIFF
--- a/src/common/parsers/Shortcode.php
+++ b/src/common/parsers/Shortcode.php
@@ -246,7 +246,7 @@ class Shortcode extends BaseParser
      *
      * @param string $text
      *
-     * @return array
+     * @return array|string
      */
     protected function parseAttributes(string $text): array
     {
@@ -268,8 +268,6 @@ class Shortcode extends BaseParser
                     $attributes[] = stripcslashes($m[8]);
                 }
             }
-        } else {
-            $attributes = ltrim($text);
         }
 
         return $attributes;


### PR DESCRIPTION
The `Shortcode::parseAttributes()` method can only return an array, but the `else` statement returns a string. I'm not sure what that `else` statement is for, so I have removed it. Please check that this is ok, otherwise the return signature should perhaps be changed to `array|string`.

Here is the error:

```
2022-07-26 18:44:30 [web.ERROR] [TypeError] verbb\doxter\common\parsers\Shortcode::parseAttributes(): Return value must be of type array, string returned
```