### PR TITLE
Fix bug in parse options

### DIFF
--- a/src/common/parsers/Header.php
+++ b/src/common/parsers/Header.php
@@ -26,8 +26,8 @@ class Header extends BaseParser
      */
     public function parse(string $source, array $options = []): mixed
     {
-        $addHeaderAnchorsTo = $options['$addHeaderAnchorsTo'] ?? ['h1', 'h2', 'h3'];
-        $startingHeaderLevel = $options['$startingHeaderLevel'] ?? 1;
+        $addHeaderAnchorsTo = $options['addHeaderAnchorsTo'] ?? ['h1', 'h2', 'h3'];
+        $startingHeaderLevel = $options['startingHeaderLevel'] ?? 1;
 
         $this->addHeaderAnchorsTo = $addHeaderAnchorsTo;
         $this->startingHeaderLevel = $startingHeaderLevel;


### PR DESCRIPTION
This fixes a bug in which the parse options are never applied, due to a misplaced `$`.