### PR TITLE
Fix selecting no linkable headers

### DIFF
--- a/src/common/parsers/Header.php
+++ b/src/common/parsers/Header.php
@@ -26,7 +26,7 @@ class Header extends BaseParser
      */
     public function parse(string $source, array $options = []): mixed
     {
-        $addHeaderAnchorsTo = $options['addHeaderAnchorsTo'] ?? ['h1', 'h2', 'h3'];
+        $addHeaderAnchorsTo = $options['addHeaderAnchorsTo'] ?? [];
         $startingHeaderLevel = $options['startingHeaderLevel'] ?? 1;
 
         $this->addHeaderAnchorsTo = $addHeaderAnchorsTo;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -11,7 +11,7 @@ class Settings extends Model
     public array $shortcodes = [];
     public string $codeBlockSnippet = '';
     public bool $addHeaderAnchors = true;
-    public array $addHeaderAnchorsTo = ['h1', 'h2', 'h3'];
+    public array|null $addHeaderAnchorsTo = ['h1', 'h2', 'h3'];
     public int $startingHeaderLevel = 1;
     public bool $addTypographyStyles = true;
     public bool $addTypographyHyphenation = true;


### PR DESCRIPTION
When no linkable headers are selected, saving the settings reverts to the default `['h1', 'h2', 'h3']`. This PR fixes that, allowing no linkable headers to be selected.