### PR TITLE
php → pre

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,10 @@ Here are a few _code block template string_ examples for the syntax highlighter
 
 ```html
 <!-- HighlightJS -->
-<pre><code class="{languageClass}">{sourceCode}</code></php>
+<pre><code class="{languageClass}">{sourceCode}</code></pre>
 
 <!-- RainbowJS -->
-<pre><code data-language="{languageClass}">{sourceCode}</code></php>
+<pre><code data-language="{languageClass}">{sourceCode}</code></pre>
 
 <!-- PrismJS -->
 <pre><code class="language-{languageClass}">{sourceCode}</code></pre>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -127,7 +127,7 @@ $('.addRainbowSnippetBtn').on('click', function(e) {
 $('.addHighlightSnippetBtn').on('click', function(e) {
     e.preventDefault();
 
-    $settingsCodeBlockSnippetTextArea.val('<pre><code class="{languageClass}">{sourceCode}</code></php>');
+    $settingsCodeBlockSnippetTextArea.val('<pre><code class="{languageClass}">{sourceCode}</code></pre>');
 });
 
 {% endjs %}


### PR DESCRIPTION
Replaces incorrect instances of `</php>` with `</pre>`.